### PR TITLE
removing the obsolete create() on S3.put

### DIFF
--- a/lib/redmine_s3/connection.rb
+++ b/lib/redmine_s3/connection.rb
@@ -64,9 +64,7 @@ module RedmineS3
       end
 
       def put(filename, data)
-        objects = self.conn.buckets[self.bucket].objects
-        object = objects[filename]
-        object = objects.create(filename) unless object.exists?
+        object = self.conn.buckets[self.bucket].objects[filename]
         options = {}
         options[:acl] = :public_read unless self.private?
         # options[:content_disposition] = "attachment; filename='#{filename}'"


### PR DESCRIPTION
this also fixes 

```
ArgumentError (:data must be provided as a String, Pathname, File, or an object that responds to #read and #eof?):
  lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb:72:in `save_attachments'
  lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb:68:in `each'
  lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb:68:in `save_attachments'
  app/controllers/issues_controller.rb:168:in `update'
```

which occurs with latest redmine and aws-sdk gem

removing the obsolete create() call fixed the problem (calling write() creates an object, if it does not exist)
