### PR TITLE
Setting content-type for attachment files on s3

### DIFF
--- a/lib/redmine_s3/attachment_patch.rb
+++ b/lib/redmine_s3/attachment_patch.rb
@@ -21,7 +21,7 @@ module RedmineS3
         if @temp_file && (@temp_file.size > 0)
           logger.debug("Uploading to #{disk_filename}")
           content = @temp_file.respond_to?(:read) ? @temp_file.read : @temp_file
-          RedmineS3::Connection.put(disk_filename, content)
+          RedmineS3::Connection.put(disk_filename, content, self.content_type)
           md5 = Digest::MD5.new
           self.digest = md5.hexdigest
         end

--- a/lib/redmine_s3/connection.rb
+++ b/lib/redmine_s3/connection.rb
@@ -63,11 +63,12 @@ module RedmineS3
         @@s3_options[:secure]
       end
 
-      def put(filename, data)
+      def put(filename, data, content_type='application/octet-stream')
         object = self.conn.buckets[self.bucket].objects[filename]
         options = {}
         options[:acl] = :public_read unless self.private?
-        # options[:content_disposition] = "attachment; filename='#{filename}'"
+        options[:content_type] = content_type if content_type
+        options[:content_disposition] = "inline; filename='#{ERB::Util.url_encode(filename)}'"
         object.write(data, options)
       end
 


### PR DESCRIPTION
Please support `content-type` headers.
