### PR TITLE
Set Content-Type and Content-Disposition on S3 objects

### DIFF
--- a/lib/redmine_s3/attachment_patch.rb
+++ b/lib/redmine_s3/attachment_patch.rb
@@ -20,10 +20,7 @@ module RedmineS3
       def put_to_s3
         if @temp_file && (@temp_file.size > 0)
           logger.debug("Uploading to #{disk_filename}")
-          content = @temp_file.respond_to?(:read) ? @temp_file.read : @temp_file
-          RedmineS3::Connection.put(disk_filename, content, self.content_type)
-          md5 = Digest::MD5.new
-          self.digest = md5.hexdigest
+          self.digest = RedmineS3::Connection.put(self, @temp_file)
         end
         @temp_file = nil # so that the model's original after_save block skips writing to the fs
       end

--- a/lib/redmine_s3/connection.rb
+++ b/lib/redmine_s3/connection.rb
@@ -1,8 +1,12 @@
 require 'aws-sdk'
+require 'stringio'
 
 AWS.config(:ssl_verify_peer => false)
 
 module RedmineS3
+  class TransferError < RuntimeError
+  end
+
   class Connection
     @@conn = nil
     @@s3_options = {
@@ -44,7 +48,8 @@ module RedmineS3
 
       def create_bucket
         bucket = self.conn.buckets[self.bucket]
-        bucket.create unless bucket.exists?
+        bucket = self.conn.buckets.create(self.bucket) unless bucket.exists?
+        bucket
       end
 
       def endpoint
@@ -63,13 +68,76 @@ module RedmineS3
         @@s3_options[:secure]
       end
 
-      def put(filename, data, content_type='application/octet-stream')
-        object = self.conn.buckets[self.bucket].objects[filename]
-        options = {}
-        options[:acl] = :public_read unless self.private?
-        options[:content_type] = content_type if content_type
-        options[:content_disposition] = "inline; filename='#{ERB::Util.url_encode(filename)}'"
-        object.write(data, options)
+      def put(attachment, data)
+        # if data is a string, turns it into a buffer
+        if data.is_a?(String)
+          data = StringIO.new(data)
+        end
+
+        do_put = Proc.new do
+          # Allows retries, if supported
+          if data.respond_to?(:seek)
+            data.seek(0)
+          end
+
+          # Object options
+          options = {
+            :content_disposition => "inline; filename='#{ERB::Util.url_encode(attachment.filename)}'",
+            :content_type => attachment.content_type,
+            :content_length => data.size,
+            # Prevent multipart upload, so that the object ETag is the content's MD5
+            :single_request => true
+          }
+          options[:acl] = :public_read unless self.private?
+
+          # Streaming upload, we'll compute the MD5 while we're at it
+          md5 = Digest::MD5.new
+          object = self.create_bucket.objects[attachment.disk_filename]
+          object = object.write(options) do |buffer, bytes|
+            if read = data.read(bytes)
+              md5.update(read)
+              buffer.write(read)
+            end
+          end
+
+          # Check digests
+          md5 = md5.hexdigest
+          if !(attachment.digest.nil? || attachment.digest == md5)
+            puts "WARNING : wrong digest for file #{attachment.disk_filename}"
+            # TODO : update attachment.digest ?
+          end
+
+          s3_md5 = self.try("get MD5 for #{object.key}") { object.etag[1...-1] }
+          if s3_md5 != md5
+            raise TransferError.new("MD5 mismatch for file #{attachment.disk_filename}, local=#{md5}, S3=#{s3_md5}")
+          end
+
+          # Returns the MD5
+          md5
+        end
+
+        # Try multiple times, if possible (i.e. data is seekable)
+        if data.respond_to?(:seek)
+          self.try("sending #attachment.disk_filename}", &do_put)
+        else
+          do_put.call
+        end
+      end
+
+      def try(name, max_tries=3, base_wait=0.25, exponent=2, &block)
+        try = 0
+        wait = base_wait
+        while true
+          begin
+            try = try + 1
+            return block.call
+          rescue => e
+            raise if try==max_tries
+            puts "WARNING : #{name} failed due to #{e} (try #{try})"
+            sleep(wait)
+            wait = wait * exponent
+          end
+        end
       end
 
       def delete(filename)

--- a/lib/tasks/files_to_s3.rake
+++ b/lib/tasks/files_to_s3.rake
@@ -2,49 +2,84 @@ namespace :redmine_s3 do
   task :files_to_s3 => :environment do
     require 'thread'
 
-    def s3_file_path(file_path)
-      File.basename(file_path).split('_').first + '/' + File.basename(file_path)
-    end
-
     # updates a single file on s3
-    def update_file_on_s3(file, objects)
-      file_path = s3_file_path(file)
-      conn = RedmineS3::Connection.conn
-      object = objects[file_path]
+    def update_file_on_s3(attachment, objects)
+      if File.exists?(attachment.diskfile)
+        object = objects[attachment.disk_filename]
 
-      # get the file modified time, which will stay nil if the file doesn't exist yet
-      # we could check if the file exists, but this saves a head request
-      s3_mtime = object.last_modified rescue nil 
+        # get the file ETag, which will stay nil if the file doesn't exist yet
+        # we could check if the file exists, but this saves a head request
+        s3_digest = object.etag[1...-1] rescue nil 
 
-      # put it on s3 if the file has been updated or it doesn't exist on s3 yet
-      if s3_mtime.nil? || s3_mtime < File.mtime(file)
-        fileObj = File.open(file, 'r')
-        RedmineS3::Connection.put(file_path, fileObj.read)
-        fileObj.close
+        # put it on s3 if the file has been updated or it doesn't exist on s3 yet
+        if s3_digest.nil?
+          puts "Sending file #{attachment.disk_filename}..."
+        elsif s3_digest != attachment.digest 
+          puts "Updating file #{attachment.disk_filename}..."
+        else
+          # puts attachment.disk_filename + ' is up-to-date on S3'
+          return
+        end
 
-        puts "Put file " + File.basename(file)
+        File.open(attachment.diskfile, 'rb') do |data|
+          RedmineS3::Connection.put(attachment, data)
+        end
       else
-        puts File.basename(file) + ' is up-to-date on S3'
+        # puts attachment.disk_filename + ' is already migrated on S3'
       end
     end
 
-    # enqueue all of the files to be "worked" on
-    fileQ = Queue.new
-    storage_path = Redmine::Configuration['attachments_storage_path'] || File.join(Rails.root, "files")
-    Dir.glob(File.join(storage_path,'*')).each do |file|
-      fileQ << file
-    end
+    # Get all of the attachments to be "worked" on
+    # TODO : batch process in order to avoid loading
+    # everything in RAM
+    attachments = Attachment.find(:all)
+
+    # Initialize progress info
+    start_time = Time.now
+    todo = attachments.length
+    done = 0
+    errors = 0
+    last_done_pct = 0
+    mutex = Mutex.new
 
     # init the connection, and grab the ObjectCollection object for the bucket
     conn = RedmineS3::Connection.establish_connection
     objects = conn.buckets[RedmineS3::Connection.bucket].objects
 
-    # create some threads to start syncing all of the queued files with s3
+    # create some threads to start syncing all of the queued attachments with s3
     threads = Array.new
     8.times do
       threads << Thread.new do
-        while !fileQ.empty?
-          update_file_on_s3(fileQ.pop, objects)
+        while true do
+          # Get attachment, bail out
+          # if no more work
+          attachment = mutex.synchronize do
+              attachments.pop
+          end
+          break if attachment.nil?
+          
+          # Actual work
+          error = 0
+          begin
+            update_file_on_s3(attachment, objects)
+          rescue => e
+            puts "Problem with #{attachment.disk_filename} : #{e}"
+            puts e.backtrace.join "\n"
+            error = 1
+          end
+
+          # Report progress
+          mutex.synchronize do
+            done = done + 1
+            errors = errors + error
+
+            done_pct = (100.0 * done / todo).to_i
+            if done_pct > last_done_pct
+              eta = Time.now + 1.0 * (todo - done) * (Time.now - start_time) / done
+              puts ">>> #{done} files (#{done_pct}%) done, #{errors} errors... ETA #{eta}"
+              last_done_pct = done_pct
+            end
+          end
         end
       end
     end
@@ -53,6 +88,5 @@ namespace :redmine_s3 do
     threads.each do |thread|
       thread.join
     end
-
   end
 end


### PR DESCRIPTION
Also, properly computes the MD5 of attachments.

`rake redmine_s3:files_to_s3` does a better job reporting progress of uploads, and retry uploads up to three times in case of failure.

This is a complete repackaging of my previous pull request in a single commit.
