### PR TITLE
Adding bundle install as a step for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This [Redmine](http://www.redmine.org) plugin makes file attachments be stored o
 2. `git clone git://github.com/ka8725/redmine_s3.git plugins/redmine_s3`
 3. `cp plugins/redmine_s3/config/s3.yml.example config/s3.yml`
 4. Edit config/s3.yml with your favourite editor
-5. `bundle install --without development test` for installing aws-sdk gem
+5. `bundle install --without development test` for installing this plugin dependencies (if you already did it, doing a `bundle install` again whould do no harm)
 6. Restart mongrel/upload to production/whatever
 7. *Optional*: Run `rake redmine_s3:files_to_s3` to upload files in your files folder to s3
 8. `rm -Rf plugins/redmine_s3/.git`


### PR DESCRIPTION
Redmine installation plugin tutorial doesn't say anything about those
gem dependencies, so I think the plugin should tell the users to do
that
