### PR TITLE
Update for redmine 2.6.

### DIFF
--- a/lib/redmine_s3/attachments_controller_patch.rb
+++ b/lib/redmine_s3/attachments_controller_patch.rb
@@ -7,7 +7,8 @@ module RedmineS3
       # Same as typing in the class
       base.class_eval do
         unloadable # Send unloadable so it will not be unloaded in development
-        before_filter :download_from_s3, :except => [:destroy, :upload]
+        before_filter :find_attachment_s3, :only => [:show, :download, :thumbnail]
+        before_filter :find_editable_attachments_s3, :only => [:edit, :update]
         skip_before_filter :file_readable
       end
     end
@@ -16,7 +17,7 @@ module RedmineS3
     end
 
     module InstanceMethods
-      def download_from_s3
+      def find_attachment_s3
         if @attachment.container.is_a?(Version) || @attachment.container.is_a?(Project)
           @attachment.increment_download
         end
@@ -27,6 +28,20 @@ module RedmineS3
                                           :disposition => (@attachment.image? ? 'inline' : 'attachment')
         else
           redirect_to(RedmineS3::Connection.object_url(@attachment.disk_filename))
+        end
+      end
+
+      def find_editable_attachments_s3
+        if @attachments
+          @attachments.each { |a| a.increment_download }
+        end
+        if RedmineS3::Connection.proxy?
+          @attachments.each do |attachment|
+            send_data RedmineS3::Connection.get(attachment.disk_filename),
+                                            :filename => filename_for_content_disposition(attachment.filename),
+                                            :type => detect_content_type(attachment),
+                                            :disposition => (attachment.image? ? 'inline' : 'attachment')
+          end
         end
       end
     end


### PR DESCRIPTION
Update for redmine 2.6.
It raises error in /attachments/wiki_pages/:id/edit without it.
Fixes #14 
Undefined method container for nil class because of `@attachment`, when only `@attachments` are defined.
