### PR TITLE
Added thumbnails, fixed a lot of things

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,17 @@
 GEM
-  remote: https://rubygems.org/
   specs:
-    aws-sdk (1.33.0)
+    aws-sdk (1.63.0)
+      aws-sdk-v1 (= 1.63.0)
+    aws-sdk-v1 (1.63.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-      uuidtools (~> 2.1)
-    json (1.8.1)
-    mini_portile (0.5.2)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
-    uuidtools (2.1.4)
+    json (1.8.2)
+    mini_portile (0.6.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk
+  aws-sdk (~> 1)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This [Redmine](http://www.redmine.org) plugin makes file attachments be stored o
 * private: boolean true/false
 * expires: integer number of seconds for private links to expire after being generated
 * proxy: boolean true/false
+* thumb_folder: string folder where attachment thumbnails are stored; defaults to 'tmp'
 * Defaults to private: false, secure: false, proxy: false, default endpoint, and default expires
 
 

--- a/assets/javascripts/redmine_s3.js
+++ b/assets/javascripts/redmine_s3.js
@@ -6,7 +6,7 @@ $(function() {
     $('.attachments .thumbnails img').one('error', function() {
         $.ajax({
             dataType: 'JSON',
-            url: $(this).attr('src') + '?update_thumb=true',
+            url: $(this).attr('data-thumbnail') + '?update_thumb=true',
             context: this
         }).done(function(data, status, response) {
             $(this).attr('src', response.responseJSON.src);

--- a/assets/javascripts/redmine_s3.js
+++ b/assets/javascripts/redmine_s3.js
@@ -1,0 +1,15 @@
+/*
+ * This script handles thumbnail image missing errors
+ */
+
+$(function() {
+    $('.attachments .thumbnails img').one('error', function() {
+        $.ajax({
+            dataType: 'JSON',
+            url: $(this).attr('src') + '?update_thumb=true',
+            context: this
+        }).done(function(data, status, response) {
+            $(this).attr('src', response.responseJSON.src);
+        });
+    });
+});

--- a/config/s3.yml.example
+++ b/config/s3.yml.example
@@ -8,6 +8,7 @@ production:
   private:
   expires:
   proxy:
+  thumb_folder:
 
 development:
   access_key_id:
@@ -19,6 +20,7 @@ development:
   private:
   expires:
   proxy:
+  thumb_folder:
 
 # Uncomment this to run plugin tests with standart redmine script
 # test:

--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,8 @@
 require 'redmine_s3'
 
-Redmine::Plugin.register :redmine_s3_attachments do
+require_dependency 'redmine_s3_hooks'
+
+Redmine::Plugin.register :redmine_s3 do
   name 'S3'
   author 'Chris Dell'
   description 'Use Amazon S3 as a storage engine for attachments'

--- a/lib/redmine_s3.rb
+++ b/lib/redmine_s3.rb
@@ -1,5 +1,6 @@
 require 'redmine_s3/attachment_patch'
 require 'redmine_s3/attachments_controller_patch'
+require 'redmine_s3/thumbnail_patch'
 require 'redmine_s3/connection'
 
 AttachmentsController.send(:include, RedmineS3::AttachmentsControllerPatch)

--- a/lib/redmine_s3.rb
+++ b/lib/redmine_s3.rb
@@ -1,8 +1,10 @@
 require 'redmine_s3/attachment_patch'
 require 'redmine_s3/attachments_controller_patch'
+require 'redmine_s3/application_helper_patch'
 require 'redmine_s3/thumbnail_patch'
 require 'redmine_s3/connection'
 
 AttachmentsController.send(:include, RedmineS3::AttachmentsControllerPatch)
 Attachment.send(:include, RedmineS3::AttachmentPatch)
+ApplicationHelper.send(:include, RedmineS3::ApplicationHelperPatch)
 RedmineS3::Connection.create_bucket

--- a/lib/redmine_s3/application_helper_patch.rb
+++ b/lib/redmine_s3/application_helper_patch.rb
@@ -12,9 +12,9 @@ module RedmineS3
 
     module InstanceMethods
       def thumbnail_tag_with_s3_patch(attachment)
-        link_to image_tag(attachment.thumbnail_s3),
+        link_to image_tag(attachment.thumbnail_s3, data: {thumbnail: thumbnail_path(attachment)}),
                 RedmineS3::Connection.object_url(attachment.disk_filename_s3),
-                :title => attachment.filename
+                title: attachment.filename
       end
     end
   end

--- a/lib/redmine_s3/application_helper_patch.rb
+++ b/lib/redmine_s3/application_helper_patch.rb
@@ -1,0 +1,21 @@
+module RedmineS3
+  module ApplicationHelperPatch
+    def self.included(base) # :nodoc:
+      base.send(:include, InstanceMethods)
+
+      base.class_eval do
+        unloadable # Send unloadable so it will not be unloaded in development
+
+        alias_method_chain :thumbnail_tag, :s3_patch
+      end
+    end
+
+    module InstanceMethods
+      def thumbnail_tag_with_s3_patch(attachment)
+        link_to image_tag(attachment.thumbnail_s3),
+                RedmineS3::Connection.object_url(attachment.disk_filename_s3),
+                :title => attachment.filename
+      end
+    end
+  end
+end

--- a/lib/redmine_s3/attachment_patch.rb
+++ b/lib/redmine_s3/attachment_patch.rb
@@ -9,6 +9,7 @@ module RedmineS3
         unloadable # Send unloadable so it will not be unloaded in development
         attr_accessor :s3_access_key_id, :s3_secret_acces_key, :s3_bucket, :s3_bucket
         after_validation :put_to_s3
+        after_create      :generate_thumbnail_s3
         before_destroy   :delete_from_s3
       end
     end
@@ -20,7 +21,7 @@ module RedmineS3
       def put_to_s3
         if @temp_file && (@temp_file.size > 0) && errors.blank?
           self.disk_directory = disk_directory || target_directory
-          self.disk_filename = Attachment.disk_filename(filename, disk_directory) if disk_filename.blank?
+          self.disk_filename  = Attachment.disk_filename(filename, disk_directory) if disk_filename.blank?
           logger.debug("Uploading to #{disk_filename}")
           content = @temp_file.respond_to?(:read) ? @temp_file.read : @temp_file
           RedmineS3::Connection.put(disk_filename_s3, filename, content, self.content_type)
@@ -40,27 +41,25 @@ module RedmineS3
 
       # Returns the full path the attachment thumbnail, or nil
       # if the thumbnail cannot be generated.
-      def thumbnail_s3(options={})
-        return nil unless Object.const_defined?(:Magick)
-        if thumbnailable?
-          size = options[:size].to_i
-          if size > 0
-            # Limit the number of thumbnails per image
-            size = (size / 50) * 50
-            # Maximum thumbnail size
-            size = 800 if size > 800
-          else
-            size = Setting.thumbnails_size.to_i
-          end
-          size         = 100 unless size > 0
-          target       = "#{id}_#{digest}_#{size}.thumb"
-          update_thumb = options[:update_thumb] || false
-          begin
-            RedmineS3::ThumbnailPatch.generate_s3_thumb(self.disk_filename_s3, target, size, update_thumb)
-          rescue => e
-            logger.error "An error occured while generating thumbnail for #{disk_filename_s3} to #{target}\nException was: #{e.message}" if logger
-            return nil
-          end
+      def thumbnail_s3(options = {})
+        return unless thumbnailable?
+        size = options[:size].to_i
+        if size > 0
+          # Limit the number of thumbnails per image
+          size = (size / 50) * 50
+          # Maximum thumbnail size
+          size = 800 if size > 800
+        else
+          size = Setting.thumbnails_size.to_i
+        end
+        size         = 100 unless size > 0
+        target       = "#{id}_#{digest}_#{size}.thumb"
+        update_thumb = options[:update_thumb] || false
+        begin
+          RedmineS3::ThumbnailPatch.generate_s3_thumb(self.disk_filename_s3, target, size, update_thumb)
+        rescue => e
+          logger.error "An error occured while generating thumbnail for #{disk_filename_s3} to #{target}\nException was: #{e.message}" if logger
+          return
         end
       end
 
@@ -68,6 +67,10 @@ module RedmineS3
         path = disk_filename
         path = File.join(disk_directory, path) unless disk_directory.blank?
         path
+      end
+
+      def generate_thumbnail_s3
+        thumbnail_s3(update_thumb: true)
       end
     end
   end

--- a/lib/redmine_s3/attachment_patch.rb
+++ b/lib/redmine_s3/attachment_patch.rb
@@ -66,6 +66,10 @@ module RedmineS3
       def disk_filename_s3
         File.join(target_directory, disk_filename)
       end
+
+      def attachment_target_directory
+        target_directory
+      end
     end
   end
 end

--- a/lib/redmine_s3/attachments_controller_patch.rb
+++ b/lib/redmine_s3/attachments_controller_patch.rb
@@ -7,7 +7,8 @@ module RedmineS3
       # Same as typing in the class
       base.class_eval do
         unloadable # Send unloadable so it will not be unloaded in development
-        before_filter :find_attachment_s3, :only => [:show, :download, :thumbnail]
+        before_filter :find_attachment_s3, :only => [:show, :download]
+        before_filter :find_thumbnail_attachment_s3, :only => [:thumbnail]
         before_filter :find_editable_attachments_s3, :only => [:edit, :update]
         skip_before_filter :file_readable
       end
@@ -42,6 +43,21 @@ module RedmineS3
                                             :type => detect_content_type(attachment),
                                             :disposition => (attachment.image? ? 'inline' : 'attachment')
           end
+        end
+      end
+
+      def find_thumbnail_attachment_s3
+        update_thumb = 'true' == params[:update_thumb]
+        url          = @attachment.thumbnail_s3({update_thumb: update_thumb})
+        return render json: {src: url} if update_thumb
+        return if url.nil?
+        if RedmineS3::Connection.proxy?
+          send_data RedmineS3::Connection.get(url),
+                    :filename => filename_for_content_disposition(@attachment.filename),
+                    :type => detect_content_type(@attachment),
+                    :disposition => (@attachment.image? ? 'inline' : 'attachment')
+        else
+          redirect_to(url)
         end
       end
     end

--- a/lib/redmine_s3/attachments_controller_patch.rb
+++ b/lib/redmine_s3/attachments_controller_patch.rb
@@ -23,12 +23,12 @@ module RedmineS3
           @attachment.increment_download
         end
         if RedmineS3::Connection.proxy?
-          send_data RedmineS3::Connection.get(@attachment.disk_filename),
+          send_data RedmineS3::Connection.get(@attachment.disk_filename_s3),
                                           :filename => filename_for_content_disposition(@attachment.filename),
                                           :type => detect_content_type(@attachment),
                                           :disposition => (@attachment.image? ? 'inline' : 'attachment')
         else
-          redirect_to(RedmineS3::Connection.object_url(@attachment.disk_filename))
+          redirect_to(RedmineS3::Connection.object_url(@attachment.disk_filename_s3))
         end
       end
 
@@ -38,7 +38,7 @@ module RedmineS3
         end
         if RedmineS3::Connection.proxy?
           @attachments.each do |attachment|
-            send_data RedmineS3::Connection.get(attachment.disk_filename),
+            send_data RedmineS3::Connection.get(attachment.disk_filename_s3),
                                             :filename => filename_for_content_disposition(attachment.filename),
                                             :type => detect_content_type(attachment),
                                             :disposition => (attachment.image? ? 'inline' : 'attachment')
@@ -52,7 +52,7 @@ module RedmineS3
         return render json: {src: url} if update_thumb
         return if url.nil?
         if RedmineS3::Connection.proxy?
-          send_data RedmineS3::Connection.get(url),
+          send_data RedmineS3::Connection.get(url, ''),
                     :filename => filename_for_content_disposition(@attachment.filename),
                     :type => detect_content_type(@attachment),
                     :disposition => (@attachment.image? ? 'inline' : 'attachment')

--- a/lib/redmine_s3/attachments_controller_patch.rb
+++ b/lib/redmine_s3/attachments_controller_patch.rb
@@ -68,7 +68,7 @@ module RedmineS3
 
       def find_thumbnail_attachment_s3
         update_thumb = 'true' == params[:update_thumb]
-        url          = @attachment.thumbnail_s3({update_thumb: update_thumb})
+        url          = @attachment.thumbnail_s3(update_thumb: update_thumb)
         return render json: {src: url} if update_thumb
         return if url.nil?
         if RedmineS3::Connection.proxy?

--- a/lib/redmine_s3/connection.rb
+++ b/lib/redmine_s3/connection.rb
@@ -94,7 +94,7 @@ module RedmineS3
 
       def delete(filename)
         object = self.object(filename)
-        object.delete if object.exists?
+        object.delete
       end
 
       def object_url(filename)

--- a/lib/redmine_s3/connection.rb
+++ b/lib/redmine_s3/connection.rb
@@ -80,7 +80,6 @@ module RedmineS3
       end
 
       def thumb_folder
-        @@s3_options[:thumb_folder]
         str = @@s3_options[:thumb_folder]
         if str.present?
           str.match(/\S+\//) ? str : "#{str}/"
@@ -89,12 +88,12 @@ module RedmineS3
         end
       end
 
-      def object(filename, target_folder = folder)
+      def object(filename, target_folder = self.folder)
         bucket = self.conn.buckets[self.bucket]
         bucket.objects[target_folder + filename]
       end
 
-      def put(filename, data, content_type='application/octet-stream', target_folder = folder)
+      def put(filename, data, content_type='application/octet-stream', target_folder = self.folder)
         object = self.object(filename, target_folder)
         options = {}
         options[:acl] = :public_read unless self.private?
@@ -103,12 +102,12 @@ module RedmineS3
         object.write(data, options)
       end
 
-      def delete(filename, target_folder = folder)
+      def delete(filename, target_folder = self.folder)
         object = self.object(filename, target_folder)
         object.delete
       end
 
-      def object_url(filename, target_folder = folder)
+      def object_url(filename, target_folder = self.folder)
         object = self.object(filename, target_folder)
         if self.private?
           options = {:secure => self.secure?}
@@ -119,7 +118,7 @@ module RedmineS3
         end
       end
 
-      def get(filename, target_folder = folder)
+      def get(filename, target_folder = self.folder)
         object = self.object(filename, target_folder)
         object.read
       end

--- a/lib/redmine_s3/connection.rb
+++ b/lib/redmine_s3/connection.rb
@@ -93,12 +93,12 @@ module RedmineS3
         bucket.objects[target_folder + filename]
       end
 
-      def put(filename, data, content_type='application/octet-stream', target_folder = self.folder)
-        object = self.object(filename, target_folder)
+      def put(disk_filename, original_filename, data, content_type='application/octet-stream', target_folder = self.folder)
+        object = self.object(disk_filename, target_folder)
         options = {}
         options[:acl] = :public_read unless self.private?
         options[:content_type] = content_type if content_type
-        options[:content_disposition] = "inline; filename=#{ERB::Util.url_encode(filename)}"
+        options[:content_disposition] = "inline; filename=#{ERB::Util.url_encode(original_filename)}"
         object.write(data, options)
       end
 

--- a/lib/redmine_s3/connection.rb
+++ b/lib/redmine_s3/connection.rb
@@ -84,7 +84,7 @@ module RedmineS3
         if str.present?
           str.match(/\S+\//) ? str : "#{str}/"
         else
-          ''
+          'tmp/'
         end
       end
 

--- a/lib/redmine_s3/connection.rb
+++ b/lib/redmine_s3/connection.rb
@@ -14,7 +14,8 @@ module RedmineS3
       :private           => false,
       :expires           => nil,
       :secure            => false,
-      :proxy             => false
+      :proxy             => false,
+      :thumb_folder      => ''
     }
 
     class << self
@@ -76,6 +77,10 @@ module RedmineS3
 
       def proxy?
         @@s3_options[:proxy]
+      end
+
+      def thumb_folder
+        @@s3_options[:thumb_folder]
       end
 
       def object(filename)

--- a/lib/redmine_s3/thumbnail_patch.rb
+++ b/lib/redmine_s3/thumbnail_patch.rb
@@ -12,7 +12,7 @@ module RedmineS3
         img = img.strip!
         img = img.resize_to_fit(size)
 
-        RedmineS3::Connection.put(target, img.to_blob, img.mime_type, target_folder)
+        RedmineS3::Connection.put(target, File.basename(target), img.to_blob, img.mime_type, target_folder)
       end
       RedmineS3::Connection.object_url(target, target_folder)
     end

--- a/lib/redmine_s3/thumbnail_patch.rb
+++ b/lib/redmine_s3/thumbnail_patch.rb
@@ -1,0 +1,18 @@
+module RedmineS3
+  module ThumbnailPatch
+    # Generates a thumbnail for the source image to target
+    def self.generate_s3_thumb(source, target, size, update_thumb = false)
+      return nil unless Object.const_defined?(:Magick)
+      if update_thumb
+        require 'open-uri'
+        img = Magick::ImageList.new
+        url = RedmineS3::Connection.object_url(source)
+        open(url, 'rb') do |f| img = img.from_blob(f.read) end
+        img = img.strip!
+        img = img.resize_to_fit(size)
+        RedmineS3::Connection.put(target, img.to_blob, img.mime_type)
+      end
+      RedmineS3::Connection.object_url(target)
+    end
+  end
+end

--- a/lib/redmine_s3/thumbnail_patch.rb
+++ b/lib/redmine_s3/thumbnail_patch.rb
@@ -3,6 +3,7 @@ module RedmineS3
     # Generates a thumbnail for the source image to target
     def self.generate_s3_thumb(source, target, size, update_thumb = false)
       return nil unless Object.const_defined?(:Magick)
+      target_folder = RedmineS3::Connection.thumb_folder
       if update_thumb
         require 'open-uri'
         img = Magick::ImageList.new
@@ -10,9 +11,10 @@ module RedmineS3
         open(url, 'rb') do |f| img = img.from_blob(f.read) end
         img = img.strip!
         img = img.resize_to_fit(size)
-        RedmineS3::Connection.put(target, img.to_blob, img.mime_type)
+
+        RedmineS3::Connection.put(target, img.to_blob, img.mime_type, target_folder)
       end
-      RedmineS3::Connection.object_url(target)
+      RedmineS3::Connection.object_url(target, target_folder)
     end
   end
 end

--- a/lib/redmine_s3/thumbnail_patch.rb
+++ b/lib/redmine_s3/thumbnail_patch.rb
@@ -2,9 +2,9 @@ module RedmineS3
   module ThumbnailPatch
     # Generates a thumbnail for the source image to target
     def self.generate_s3_thumb(source, target, size, update_thumb = false)
-      return nil unless Object.const_defined?(:Magick)
       target_folder = RedmineS3::Connection.thumb_folder
       if update_thumb
+        return unless Object.const_defined?(:Magick)
         require 'open-uri'
         img = Magick::ImageList.new
         url = RedmineS3::Connection.object_url(source)

--- a/lib/redmine_s3_hooks.rb
+++ b/lib/redmine_s3_hooks.rb
@@ -1,0 +1,7 @@
+# This class hooks into Redmine's View Listeners in order to add content to the page
+class RedmineS3Hooks < Redmine::Hook::ViewListener
+
+  def view_layouts_base_html_head(context = {})
+    javascript_include_tag 'redmine_s3.js', :plugin => 'redmine_s3'
+  end
+end

--- a/lib/tasks/files_to_s3.rake
+++ b/lib/tasks/files_to_s3.rake
@@ -3,29 +3,33 @@ namespace :redmine_s3 do
     require 'thread'
 
     def s3_file_path(file_path)
-      file_path.split('/').last(3).join('/')
+      file_name  = File.basename(file_path)
+      attachment = Attachment.find_by_disk_filename(File.basename(file_name))
+      file_name  = File.join(attachment.attachment_target_directory, file_name) unless attachment.nil?
+      file_name
     end
 
     # updates a single file on s3
     def update_file_on_s3(file, objects)
-      file_path = s3_file_path(file)
+      source    = file[:source]
+      file_path = file[:target]
       object = objects[file_path]
-
+      return if file_path.nil?
       # get the file modified time, which will stay nil if the file doesn't exist yet
       # we could check if the file exists, but this saves a head request
       s3_mtime = object.last_modified rescue nil 
 
       # put it on s3 if the file has been updated or it doesn't exist on s3 yet
-      if s3_mtime.nil? || s3_mtime < File.mtime(file)
-        file_obj = File.open(file, 'r')
+      if s3_mtime.nil? || s3_mtime < File.mtime(source)
+        file_obj = File.open(source, 'r')
         default_content_type = 'application/octet-stream'
         content_type = IO.popen(["file", "--brief", "--mime-type", file_obj.path], in: :close, err: :close) { |io| io.read.chomp } || default_content_type rescue default_content_type
         RedmineS3::Connection.put(file_path, file_obj.read, content_type)
         file_obj.close
 
-        puts "Put file #{File.basename(file)}"
+        puts "Put file #{file_path}"
       else
-        puts File.basename(file) + ' is up-to-date on S3'
+        puts File.basename(source) + ' is up-to-date on S3'
       end
     end
 
@@ -33,7 +37,7 @@ namespace :redmine_s3 do
     file_q = Queue.new
     storage_path = Redmine::Configuration['attachments_storage_path'] || File.join(Rails.root, "files")
     Dir.glob(File.join(storage_path,'**/*')).each do |file|
-      file_q << file if File.file? file
+      file_q << {source: file, target: s3_file_path(file)} if File.file? file
     end
 
     # init the connection, and grab the ObjectCollection object for the bucket
@@ -49,7 +53,7 @@ namespace :redmine_s3 do
         end
       end
     end
-    
+
     # wait on all of the threads to finish
     threads.each do |thread|
       thread.join

--- a/lib/tasks/files_to_s3.rake
+++ b/lib/tasks/files_to_s3.rake
@@ -3,13 +3,12 @@ namespace :redmine_s3 do
     require 'thread'
 
     def s3_file_path(file_path)
-      File.basename(file_path)
+      file_path.split('/').last(3).join('/')
     end
 
     # updates a single file on s3
     def update_file_on_s3(file, objects)
       file_path = s3_file_path(file)
-      conn = RedmineS3::Connection.conn
       object = objects[file_path]
 
       # get the file modified time, which will stay nil if the file doesn't exist yet
@@ -18,23 +17,23 @@ namespace :redmine_s3 do
 
       # put it on s3 if the file has been updated or it doesn't exist on s3 yet
       if s3_mtime.nil? || s3_mtime < File.mtime(file)
-        fileObj = File.open(file, 'r')
+        file_obj = File.open(file, 'r')
         default_content_type = 'application/octet-stream'
-        content_type = IO.popen(["file", "--brief", "--mime-type", fileObj.path], in: :close, err: :close) { |io| io.read.chomp } || default_content_type rescue default_content_type
-        RedmineS3::Connection.put(file_path, fileObj.read, content_type)
-        fileObj.close
+        content_type = IO.popen(["file", "--brief", "--mime-type", file_obj.path], in: :close, err: :close) { |io| io.read.chomp } || default_content_type rescue default_content_type
+        RedmineS3::Connection.put(file_path, file_obj.read, content_type)
+        file_obj.close
 
-        puts "Put file " + File.basename(file)
+        puts "Put file #{File.basename(file)}"
       else
         puts File.basename(file) + ' is up-to-date on S3'
       end
     end
 
     # enqueue all of the files to be "worked" on
-    fileQ = Queue.new
+    file_q = Queue.new
     storage_path = Redmine::Configuration['attachments_storage_path'] || File.join(Rails.root, "files")
     Dir.glob(File.join(storage_path,'**/*')).each do |file|
-      fileQ << file if File.file? file
+      file_q << file if File.file? file
     end
 
     # init the connection, and grab the ObjectCollection object for the bucket
@@ -45,8 +44,8 @@ namespace :redmine_s3 do
     threads = Array.new
     8.times do
       threads << Thread.new do
-        while !fileQ.empty?
-          update_file_on_s3(fileQ.pop, objects)
+        while !file_q.empty?
+          update_file_on_s3(file_q.pop, objects)
         end
       end
     end

--- a/lib/tasks/files_to_s3.rake
+++ b/lib/tasks/files_to_s3.rake
@@ -20,7 +20,7 @@ namespace :redmine_s3 do
       if s3_mtime.nil? || s3_mtime < File.mtime(file)
         fileObj = File.open(file, 'r')
         default_content_type = 'application/octet-stream'
-        content_type = Mime::Type.lookup_by_extension(File.extname(fileObj)[1..-1]) || default_content_type rescue default_content_type
+        content_type = Mime::Type.lookup_by_extension(File.extname(fileObj)[1..-1]).downcase || default_content_type rescue default_content_type
         RedmineS3::Connection.put(file_path, fileObj.read, content_type)
         fileObj.close
 

--- a/lib/tasks/files_to_s3.rake
+++ b/lib/tasks/files_to_s3.rake
@@ -19,7 +19,9 @@ namespace :redmine_s3 do
       # put it on s3 if the file has been updated or it doesn't exist on s3 yet
       if s3_mtime.nil? || s3_mtime < File.mtime(file)
         fileObj = File.open(file, 'r')
-        RedmineS3::Connection.put(file_path, fileObj.read)
+        default_content_type = 'application/octet-stream'
+        content_type = Mime::Type.lookup_by_extension(File.extname(fileObj)[1..-1]) || default_content_type rescue default_content_type
+        RedmineS3::Connection.put(file_path, fileObj.read, content_type)
         fileObj.close
 
         puts "Put file " + File.basename(file)

--- a/lib/tasks/files_to_s3.rake
+++ b/lib/tasks/files_to_s3.rake
@@ -2,19 +2,23 @@ namespace :redmine_s3 do
   task :files_to_s3 => :environment do
     require 'thread'
 
-    def s3_file_path(file_path)
-      file_name  = File.basename(file_path)
-      attachment = Attachment.find_by_disk_filename(File.basename(file_name))
-      file_name  = File.join(attachment.attachment_target_directory, file_name) unless attachment.nil?
-      file_name
+    def s3_file_data(file_path)
+      target     = filename = File.basename(file_path)
+      attachment = Attachment.find_by_disk_filename(File.basename(target))
+      unless attachment.nil?
+        target   = File.join(attachment.disk_directory, target) unless attachment.disk_directory.blank?
+        filename = attachment.filename unless attachment.filename.blank?
+      end
+      {source: file_path, target: target, filename: filename}
     end
 
     # updates a single file on s3
-    def update_file_on_s3(file, objects)
-      source    = file[:source]
-      file_path = file[:target]
-      object = objects[file_path]
-      return if file_path.nil?
+    def update_file_on_s3(data, objects)
+      source   = data[:source]
+      target   = data[:target]
+      filename = data[:filename]
+      object = objects[RedmineS3::Connection.folder + target]
+      return if target.nil?
       # get the file modified time, which will stay nil if the file doesn't exist yet
       # we could check if the file exists, but this saves a head request
       s3_mtime = object.last_modified rescue nil 
@@ -22,12 +26,16 @@ namespace :redmine_s3 do
       # put it on s3 if the file has been updated or it doesn't exist on s3 yet
       if s3_mtime.nil? || s3_mtime < File.mtime(source)
         file_obj = File.open(source, 'r')
+        if Setting.attachment_max_size.to_i.kilobytes <= file_obj.size
+          puts "File #{target} cannot be uploaded because it exceeds the maximum allowed file size (#{Setting.attachment_max_size.to_i.kilobytes}) "
+          return
+        end
         default_content_type = 'application/octet-stream'
         content_type = IO.popen(["file", "--brief", "--mime-type", file_obj.path], in: :close, err: :close) { |io| io.read.chomp } || default_content_type rescue default_content_type
-        RedmineS3::Connection.put(file_path, file_obj.read, content_type)
+        RedmineS3::Connection.put(target, filename, file_obj.read, content_type)
         file_obj.close
 
-        puts "Put file #{file_path}"
+        puts "Put file #{target}"
       else
         puts File.basename(source) + ' is up-to-date on S3'
       end
@@ -37,7 +45,7 @@ namespace :redmine_s3 do
     file_q = Queue.new
     storage_path = Redmine::Configuration['attachments_storage_path'] || File.join(Rails.root, "files")
     Dir.glob(File.join(storage_path,'**/*')).each do |file|
-      file_q << {source: file, target: s3_file_path(file)} if File.file? file
+      file_q << s3_file_data(file) if File.file? file
     end
 
     # init the connection, and grab the ObjectCollection object for the bucket


### PR DESCRIPTION
Forked your plugin, here are my changes:
1. Image thumbnail generation introduced. Image thumbnail is generated if it fails to display once page is opened (there is an AJAX call to server here). Folder for thumbnails is specified in config.
2. Files are now stored using relative paths with default redmine folder structure (file_folder/year/month/file.ext). It is based on “disk_directory” column of the database.
3. Now files have their original filenames included into “Content-Disposition” value of S3 object so that browser downloads files with original filenames without a digital prefix (e.g. image.jpg instead of 150319143442_image.jpg).
4. URLs for thumbnails and images use full URL to S3 without the 'go to redmine-server => redirect to S3' behavior. Other files are still served with redirect.
5. Fixed "View" (clicking the “Magnifier” icon to the right from the file name) action for text files and diffs.
6. files_to_s3 task now sets correct “Content-Type” and “Content-Disposition” for files. The task searches correct directory in database before uploading files to S3.
7. files_to_s3 file existence check was fixed and now uses folder from S3 config.
8. Max file size validation using redmine attachment_max_size config was added both for task and for new files.
This update targets Redmine 3.0.0 and should work with 2.6.x versions.